### PR TITLE
sdm660-common: fix permission denial

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-Copyright 2017 - The LineageOS Project
+Copyright 2018 - The LineageOS Project
 
 =====
 

--- a/rootdir/etc/init.target.rc
+++ b/rootdir/etc/init.target.rc
@@ -67,6 +67,9 @@ on boot
     chown system system /dev/goodix_fp
     chmod 0644          /dev/goodix_fp
 
+    chmod 0664 /sys/devices/virtual/graphics/fb0/idle_time
+    chown system graphics /sys/devices/virtual/graphics/fb0/idle_time
+
 #Load WLAN driver
    setprop wlan.driver.status "ok"
 


### PR DESCRIPTION
fix permission denial for /sys/devices/virtual/graphics/fb0/idle_time